### PR TITLE
Undo attack

### DIFF
--- a/js/models/Attack.js
+++ b/js/models/Attack.js
@@ -75,5 +75,13 @@ var Attack = Backbone.Model.extend({
                 resoView.model.set("energyTotal", energy - damage);
             }
         });
+    },
+    undoDamage: function () {
+        var dpr = this.get("damagePerResonator");
+        _.each(resonatorViews, function (resoView, i) {
+            var energy = resoView.model.get("energyTotal");
+            var damage = dpr[i].damage;
+            resoView.model.set("energyTotal", energy + damage);
+        });
     }
 });

--- a/js/models/AttackCollection.js
+++ b/js/models/AttackCollection.js
@@ -1,3 +1,12 @@
 var AttackCollection = Backbone.Collection.extend({
-    model: Attack
+    model: Attack,
+    add: function(model, options) {
+        // attack.attack();
+        return Backbone.Collection.prototype.add.call(this, model, options);
+    },
+    pop: function(options) {
+        var popd = Backbone.Collection.prototype.pop.call(this, options);
+        popd.undoDamage();
+        return popd;
+    }
 });

--- a/js/views/AttackInfoView.js
+++ b/js/views/AttackInfoView.js
@@ -1,7 +1,8 @@
 var AttackInfoView = Backbone.View.extend({
     events: {
         "mouseover": "showPosition",
-        "mouseout": "hidePosition"
+        "mouseout": "hidePosition",
+        "click .undo": "undoAttack"
     },
     showPosition: function () {
         playerView.model.set({x: this.model.get("x"), y: this.model.get("y")});
@@ -21,7 +22,15 @@ var AttackInfoView = Backbone.View.extend({
         var energyPortalMax = this.model.get("energyPortalMax");
         var percentage = Math.round(energyPortal / energyPortalMax * 1000) / 10;
         html += 'Dmg: ' + Math.round(damageTotal / 1000 * 10) / 10 + 'K, Portal: ' + Math.round(energyPortal / 1000 * 10) / 10 + 'K/' + energyPortalMax / 1000 + 'K (' + percentage + '%)';
+        if(this.model.collection.indexOf(this.model) == this.model.collection.length-1)
+            html += '&nbsp;-&nbsp;<span style="cursor: pointer" class="undo">undo</span>';
         this.$el.html(html);
         return this;
+    },
+    undoAttack: function() {
+        if(this.model.collection.indexOf(this.model) == this.model.collection.length-1) {
+            this.model.collection.pop();
+            playerView.hide();
+        }
     }
 });

--- a/js/views/AttackListView.js
+++ b/js/views/AttackListView.js
@@ -1,8 +1,8 @@
 var AttackListView = Backbone.View.extend({
     initialize: function () {
         _.bindAll(this, "addOne", "render");
-        this.listenTo(this.collection, "add", this.addOne);
-        this.listenTo(this.collection, "reset", this.render)
+        //this.listenTo(this.collection, "add", this.addOne);
+        this.listenTo(this.collection, "add remove reset", this.render);
     },
     addOne: function (at) {
         var av = new AttackInfoView({
@@ -14,6 +14,6 @@ var AttackListView = Backbone.View.extend({
         this.$el.html("");
         this.collection.each(function (at, i) {
             this.addOne(at);
-        });
+        }, this);
     }
 });

--- a/js/views/AttackSummaryView.js
+++ b/js/views/AttackSummaryView.js
@@ -1,11 +1,12 @@
 var AttackSummaryView = Backbone.View.extend({
     initialize: function () {
         _.bindAll(this, "render");
-        this.listenTo(this.collection, "add change reset", this.render);
+        this.listenTo(this.collection, "add change remove reset", this.render);
         this.render();
     },
     events: {
-        "click .reset": "reset"
+        "click .reset": "reset",
+        "click .undo": "undo"
     },
     render: function () {
         var burstercount = [];
@@ -22,10 +23,16 @@ var AttackSummaryView = Backbone.View.extend({
                 htmls.push(b + 'x <span style="color:' + level_color[i + 1] + '">L' + (i + 1) + '</span>');
             }
         }
-        this.$el.html(htmls.join(", ") + ' <span style="cursor: pointer" class="reset">Reset</span>');
+        var resetSpan = ' <span style="cursor: pointer" class="reset">Reset</span>';
+        var undoSpan = ' <span style="cursor: pointer" class="undo">Undo</span>';
+        this.$el.html(htmls.join(", ") + resetSpan + " - " + undoSpan);
     },
     reset: function () {
         this.collection.reset();
         portal.reset();
+    },
+    undo: function () {
+        if(this.collection.length > 0)
+            this.collection.pop();
     }
 });

--- a/js/views/DamageHeatMapView.js
+++ b/js/views/DamageHeatMapView.js
@@ -5,7 +5,7 @@ var DamageHeatMapView = Backbone.View.extend({
     initialize: function () {
         _.bindAll(this, "render", "createDataset");
         this.listenTo(this.model, 'change', this.check);
-        this.listenTo(attacks, 'add', this.check);
+        this.listenTo(attacks, 'add remove', this.check);
     },
     check: function (a) {
         if (this.model.get("heatmap")) {


### PR DESCRIPTION
Here is a minimal set of changes to support undoing of the last attack in the list.
The Attack model features a function that does the opposite of doDamange; the function is triggered directly by "pop"ping the AttackCollection.
Both the AttackInfo and AttackSummary views feature new "undo" clickable elements, that "pop" the AttackCollection.  
The AttackList and DamageHeatMap views listen to the "remove" event of the AttackCollection.  In particular AttackList re-renders at every change, so that the "undo" clickable element is present only for the last attack in the list, to avoid confusing users.
